### PR TITLE
chore: add Kiichain mainnet and testnet links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
 ## KiiChain RWA SDK
 
 The RWA (Real World Asset) SDK is a Rust library for interacting with tokenized
-real-world assets on Cosmos-based blockchains. It provides functionality for
-token operations, identity management, and compliance handling.
+real-world assets on Kiichain. It provides functionality for token operations,
+identity management, and compliance handling.
+
+### Networks
+
+| Network | Chain ID | Cosmos RPC | Denom |
+| ------- | -------- | ---------- | ----- |
+| Mainnet | `kiichain_1783-1` | `https://rpc.kiivalidator.com` | `akii` |
+| Testnet Oro | `oro_1336-1` | `https://rpc.uno.sentry.testnet.v3.kiivalidator.com` | `akii` |
+
+Bech32 prefix: `kii`
+
+- Mainnet configs: [KiiChain/mainnets](https://github.com/KiiChain/mainnets/tree/main/kiichain)
+- Testnet configs: [KiiChain/testnets](https://github.com/KiiChain/testnets/tree/main/testnet_oro)
 
 ### Features
 
@@ -19,23 +31,22 @@ use cosmrs::crypto::secp256k1::SigningKey;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize the client
+    // Mainnet — use testnet RPC / oro_1336-1 for Oro
     let client = RwaClient::new(
-        "http://rpc.example.com:26657",
-        "my-chain-id",
-        "cosmos1token...",
-        "cosmos1identity...",
-        "cosmos1compliance...",
-        "sei",
+        "https://rpc.kiivalidator.com",
+        "kiichain_1783-1",
+        "kii1token...",
+        "kii1identity...",
+        "kii1compliance...",
+        "akii",
         "gas_price"
-
     )?;
 
     // Perform a token transfer
     let signer = SigningKey::from_slice(&[/* your private key */])?;
     let transfer_result = client.transfer(TransferMessageRequest {
-        from: "cosmos1sender...".to_string(),
-        to: "cosmos1recipient...".to_string(),
+        from: "kii1sender...".to_string(),
+        to: "kii1recipient...".to_string(),
         amount: 100,
         signer,
         gas_limit
@@ -44,7 +55,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Check a balance
     let balance = client.balance(TokenInfoRequest {
-        address: "cosmos1address...".to_string(),
+        address: "kii1address...".to_string(),
     }).await?;
     println!("Balance: {}", balance.balance);
 

--- a/examples/asset_tokenization.rs
+++ b/examples/asset_tokenization.rs
@@ -114,7 +114,7 @@ impl AssetTokenization {
         // Set up country restriction module for geographic compliance
         let cr_module_request = ComplianceModuleRequest {
             from: self.issuer_address.clone(),
-            module_addr: "cosmos1cr...".to_string(),
+            module_addr: "kii1cr...".to_string(),
             signer: SigningKey::from_slice(&[/* your private key */])?,
             gas_limit: 10,
         };
@@ -188,7 +188,7 @@ impl AssetTokenization {
     ) -> Result<String, Box<dyn std::error::Error>> {
         // Verify investor's compliance status
         let compliance_check = CheckUserForTokenComplianceRequest {
-            token_address: "cosmos1token...".to_string(),
+            token_address: "kii1token...".to_string(),
             from: investor_address.to_string(),
         };
 
@@ -232,7 +232,7 @@ impl AssetTokenization {
 
         // Verify current compliance status
         let compliance_check = CheckUserForTokenComplianceRequest {
-            token_address: "cosmos1token...".to_string(),
+            token_address: "kii1token...".to_string(),
             from: investor_address.to_string(),
         };
         let is_compliant = self.client.check_token_compliance(compliance_check).await?;

--- a/examples/compliance.rs
+++ b/examples/compliance.rs
@@ -4,18 +4,18 @@ use erc3643sdk::{compliance::request::ComplianceModuleRequest, RwaClient};
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = RwaClient::new(
-        "rpc_url",
-        "chain_id",
-        "token_address",
-        "identity_address",
-        "compliance_address",
-        "sei",
+        "https://rpc.kiivalidator.com",
+        "kiichain_1783-1",
+        "kii1token...",
+        "kii1identity...",
+        "kii1compliance...",
+        "akii",
         10,
     )?;
 
     // Add a compliance module
     let add_module_request = ComplianceModuleRequest {
-        from: "cosmos1sender...".to_string(),
+        from: "kii1sender...".to_string(),
         module_addr: "kyc_module_addr...".to_string(),
         signer: SigningKey::from_slice(&[/* your private key */])?,
         gas_limit: 5000,
@@ -30,8 +30,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Update a compliance module (set to active)
     let update_module_request = ComplianceModuleRequest {
-        from: "cosmos1sender...".to_string(),
-        module_addr: "cosmos1module...".to_string(),
+        from: "kii1sender...".to_string(),
+        module_addr: "kii1module...".to_string(),
         signer: SigningKey::from_slice(&[/* your private key */])?,
         gas_limit: 5000,
     };
@@ -45,8 +45,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Remove a compliance module
     let remove_module_request = ComplianceModuleRequest {
-        from: "cosmos1sender...".to_string(),
-        module_addr: "cosmos1module...".to_string(),
+        from: "kii1sender...".to_string(),
+        module_addr: "kii1module...".to_string(),
         signer: SigningKey::from_slice(&[/* your private key */])?,
         gas_limit: 5000,
     };

--- a/examples/identity.rs
+++ b/examples/identity.rs
@@ -9,20 +9,20 @@ use erc3643sdk::RwaClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize the client
+    // Mainnet — use testnet RPC / oro_1336-1 for Oro
     let client = RwaClient::new(
-        "http://rpc.example.com:26657",
-        "my-chain-id",
-        "cosmos1token...",
-        "cosmos1identity...",
-        "cosmos1compliance...",
-        "sei",
+        "https://rpc.kiivalidator.com",
+        "kiichain_1783-1",
+        "kii1token...",
+        "kii1identity...",
+        "kii1compliance...",
+        "akii",
         10,
     )?;
 
     // Add a new identity
     let add_identity_request = AddIdentityRequest {
-        from: "cosmos1sender...".to_string(),
+        from: "kii1sender...".to_string(),
         country: "US".to_string(),
         signer: SigningKey::from_slice(&[/* your private key */])?,
         gas_limit: 5000,
@@ -32,9 +32,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Update an identity
     let update_identity_request = UpdateIdentityRequest {
-        from: "cosmos1sender...".to_string(),
+        from: "kii1sender...".to_string(),
         new_country: "CA".to_string(),
-        identity_owner: "cosmos1owner...".to_string(),
+        identity_owner: "kii1owner...".to_string(),
         signer: SigningKey::from_slice(&[/* your private key */])?,
         gas_limit: 5000,
     };
@@ -46,14 +46,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Add a claim to an identity
     let add_claim_request = AddClaimRequest {
-        from: "cosmos1issuer...".to_string(),
+        from: "kii1issuer...".to_string(),
         claim: Claim {
             topic: Uint128::new(1),
-            issuer: "cosmos1issuer...".to_string(),
+            issuer: "kii1issuer...".to_string(),
             data: Binary::from(b"claim data"),
             uri: "https://example.com/claim".to_string(),
         },
-        identity_owner: "cosmos1owner...".to_string(),
+        identity_owner: "kii1owner...".to_string(),
         signer: SigningKey::from_slice(&[/* your private key */])?,
         gas_limit: 5000,
     };
@@ -62,16 +62,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Get validated claims for an identity
     let get_claims_request = GetValidatedClaimsRequest {
-        identity_owner: "cosmos1owner...".to_string(),
+        identity_owner: "kii1owner...".to_string(),
     };
     let claims = client.get_validated_claims(get_claims_request).await?;
     println!("Validated claims: {:?}", claims);
 
     // Remove a claim from an identity
     let remove_claim_request = RemoveClaimRequest {
-        from: "cosmos1issuer...".to_string(),
+        from: "kii1issuer...".to_string(),
         claim_topic: Uint128::new(1),
-        identity_owner: "cosmos1owner...".to_string(),
+        identity_owner: "kii1owner...".to_string(),
         signer: SigningKey::from_slice(&[/* your private key */])?,
         gas_limit: 5000,
     };
@@ -83,8 +83,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Remove an identity
     let remove_identity_request = RemoveIdentityRequest {
-        from: "cosmos1sender...".to_string(),
-        identity_owner: "cosmos1owner...".to_string(),
+        from: "kii1sender...".to_string(),
+        identity_owner: "kii1owner...".to_string(),
         signer: SigningKey::from_slice(&[/* your private key */])?,
         gas_limit: 5000,
     };
@@ -96,8 +96,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Check token compliance for a user
     let compliance_request = CheckUserForTokenComplianceRequest {
-        token_address: "cosmos1token...".to_string(),
-        from: "cosmos1user...".to_string(),
+        token_address: "kii1token...".to_string(),
+        from: "kii1user...".to_string(),
     };
     let is_compliant = client.check_token_compliance(compliance_request).await?;
     println!("Is user compliant: {}", is_compliant);

--- a/examples/token_transfer.rs
+++ b/examples/token_transfer.rs
@@ -7,12 +7,12 @@ use erc3643sdk::{
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = RwaClient::new(
-        "rpc_url",
-        "chain_id",
-        "token_address",
-        "identity_address",
-        "compliance_address",
-        "sei",
+        "https://rpc.kiivalidator.com",
+        "kiichain_1783-1",
+        "kii1token...",
+        "kii1identity...",
+        "kii1compliance...",
+        "akii",
         10,
     )?;
 
@@ -20,8 +20,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Perform a token transfer
     let transfer_request = TransferMessageRequest {
-        from: "cosmos1sender...".to_string(),
-        to: "cosmos1recipient...".to_string(),
+        from: "kii1sender...".to_string(),
+        to: "kii1recipient...".to_string(),
         amount: 100,
         signer: signer,
         gas_limit: 5000,
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Check balance
     let balance_request = TokenInfoRequest {
-        address: "cosmos1sender...".to_string(),
+        address: "kii1sender...".to_string(),
     };
     let balance = client.balance(balance_request).await?;
     println!("Balance: {}", balance.balance);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 //! # RWA SDK
 //!
 //! The RWA (Real World Asset) SDK is a Rust library for interacting with tokenized
-//! real-world assets on Cosmos-based blockchains. It provides functionality for
-//! token operations, identity management, and compliance handling.
+//! real-world assets on Kiichain. It provides functionality for token operations,
+//! identity management, and compliance handling.
 //!
 //! ## Features
 //!
@@ -19,14 +19,14 @@
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     // Initialize the client
+//!     // Mainnet — use testnet RPC / oro_1336-1 for Oro
 //!     let client = RwaClient::new(
-//!         "http://rpc.example.com:26657",
-//!         "my-chain-id",
-//!         "cosmos1token...",
-//!         "cosmos1identity...",
-//!         "cosmos1compliance...",
-//!         "sei",
+//!         "https://rpc.kiivalidator.com",
+//!         "kiichain_1783-1",
+//!         "kii1token...",
+//!         "kii1identity...",
+//!         "kii1compliance...",
+//!         "akii",
 //!         "gas_price"
 //!
 //!     )?;
@@ -34,8 +34,8 @@
 //!     // Perform a token transfer
 //!     let signer = SigningKey::from_slice(&[/* your private key */])?;
 //!     let transfer_result = client.transfer(TransferMessageRequest {
-//!         from: "cosmos1sender...".to_string(),
-//!         to: "cosmos1recipient...".to_string(),
+//!         from: "kii1sender...".to_string(),
+//!         to: "kii1recipient...".to_string(),
 //!         amount: 100,
 //!         signer,
 //!         gas_limit
@@ -44,7 +44,7 @@
 //!
 //!     // Check a balance
 //!     let balance = client.balance(TokenInfoRequest {
-//!         address: "cosmos1address...".to_string(),
+//!         address: "kii1address...".to_string(),
 //!     }).await?;
 //!     println!("Balance: {}", balance.balance);
 //!


### PR DESCRIPTION
# Description

Updates README, lib docs, and examples with Kiichain mainnet (`kiichain_1783-1`) and Oro testnet (`oro_1336-1`) RPC/chain ID/`akii`/`kii` placeholders (replacing generic cosmos/sei examples).

## Type of change

- [x] Documentation (updates documentation on the project)
- [x] chore (Updates on dependencies, gitignore, etc)

# How Has This Been Tested?

- [x] Reviewed links/examples against `mainnets` / `testnets` endpoint lists